### PR TITLE
feat: add Ctrl+L support for clearing screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,6 +38,12 @@ function App() {
         historyLocation++;
         setBoxValue(commandHistory[historyLocation]);
       }
+    } else if (event.ctrlKey && event.key === 'l') {
+      event.preventDefault();
+      historyLocation = commandHistory.length;
+      history = [];
+      setCommandHistory(commandHistory.slice());
+      setBoxValue(boxValue);
     } else if (event.key === 'Enter') {
       historyLocation = commandHistory.length;
       history.push(


### PR DESCRIPTION
Title. Just makes it so that `^L` clears the screen. It also mimics the behavior on many terminal emulators where it still preserves text you may have written before hitting `^L`. Hitting `^L` does not update command history.

More visually, the state transition is as so:

- Before:
  ```
  ... STUFF ...
  ... STUFF ...
  prompt$ text
  ```
  - History state = $H$
- After (hit `^L`):
  ```
  prompt$ text
  ```
  - History state = $H$ (unchanged)